### PR TITLE
Fix `startGemstone` and `stopGemstone` and stop relying on seaside ones

### DIFF
--- a/bin/gs/README.md
+++ b/bin/gs/README.md
@@ -1,5 +1,5 @@
 # Wrapper scripts for startstone and stopstone
 
-Passwords are needed to run these two commands, and those are extractec by sourcing `$GEMSTONE/seaside/etc/gemstone.secret`.
+Passwords are needed to run these two commands, and those are extracted from .topazini file.
 
-Feel free to change these two scripts i you prefer to be prompted for the passwords on every invocation.
+Feel free to change these two scripts if you prefer to be prompted for the passwords on every invocation.

--- a/bin/gs/startGemstone
+++ b/bin/gs/startGemstone
@@ -17,6 +17,6 @@ fi
 
 echo "Starting stone: $GEMSTONE_NAME"
 
-$GEMSTONE/seaside/bin/stopGemstone $GEMSTONE_CURATOR_PASS
 
+$GS_HOME/server/bin/gs/stopGemstone
 $GEMSTONE/bin/startstone $* $GEMSTONE_NAME -z $GEMSTONE_SYS_CONF -l $GEMSTONE_LOGDIR/$GEMSTONE_NAME.log

--- a/bin/gs/stopGemstone
+++ b/bin/gs/stopGemstone
@@ -15,4 +15,10 @@ else
       exit_1_banner "Missing password file $GEMSTONE/seaside/etc/gemstone.secret"
 fi
 
-$GEMSTONE/bin/stopstone -i $GEMSTONE_NAME DataCurator $GEMSTONE_CURATOR_PASS
+# The user may have specified a different Gemstone user than DataCurator in createStone script. In addition, it could have changed the password of DataCurator.
+# Therefore, the most reliable way to stop the stone is to grab the user and password either from the .topazini or the tODE description file.
+# To avoid storing this info in yet another place, and since currently this is the only place where we must extract the user and pass,
+# we simply extract it from .topazini using a perl script. This could be replaced by other means too
+$GEMSTONE/bin/stopstone -i $GEMSTONE_NAME `perl -nle"print $& if m{(?<=user )[^ ]+}" $GEMSTONE_STONE_DIR/.topazini` `perl -nle"print $& if m{(?<=password )[^ ]+}" $GEMSTONE_STONE_DIR/.topazini`
+
+


### PR DESCRIPTION
As we now allow custom GemStone user and pass, we should not rely anymore on Seaside startGemstone and stopGemstone anymore as they do not support having different DataCurator passwords for different stones. Please feel free to replace/change the perl script to extract username and pass from .topazini

What do you  think Dale? I like the idea (and it fixes my issue), but I would like to get rid of the perl script. 